### PR TITLE
Add a CutList data structure.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,26 @@ extern crate ripsaw;
 use std::io;
 
 use ripsaw::Lumber;
+use ripsaw::CutList;
 
 fn main() {
-    let mut input = String::new();
+    let mut input;
+    let mut cut_list = CutList::new(None);
 
-    println!("Enter your lumber need: ");
-    io::stdin()
-        .read_line(&mut input)
-        .expect("Failed to read lumber input string");
+    loop {
+        input = String::new();
+        println!("Enter your lumber need (q to quit): ");
+        io::stdin()
+            .read_line(&mut input)
+            .expect("Failed to read lumber input string");
 
-    let lumber = Lumber::create_from_spec(input);
-    println!("Lumber needed: {}", lumber);
+        if input.contains("q") {
+            break;
+        }
+
+        let lumber = Lumber::create_from_spec(&input);
+        cut_list.add(lumber);
+    }
+
+    println!("{}", cut_list);
 }

--- a/src/measurements.rs
+++ b/src/measurements.rs
@@ -31,11 +31,11 @@ fn get_from_spec_token(spec_token: &str, desired_unit: Units) -> f64 {
     let mut parse_result: f64;
     let replaced = spec_token.trim().replace("'", "").replace("\"", "");
     let result = replaced.parse();
-    match result {
+
+    parse_result = match result {
         Ok(v) => v,
         Err(e) => panic!("Unable to parse result {} due to {}", replaced, e),
     };
-    parse_result = result.unwrap();
 
     match desired_unit {
         Units::Feet => if spec_token.ends_with("\"") {


### PR DESCRIPTION
This data structure currently only contains the boards that are necessary
for purchase, as specified directly by the user. Over time, we're going to
modify this data structure to contain two separate aspects: a list of
boards that need to be purchased, in nominal form, and a listing of cuts
that need to be made to these boards in order to result in the final
configuration the user requires.

Refs #3.