### PR TITLE
Add a configuration to ripsaw.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ path = "src/lib.rs"
 
 [dependencies]
   tokesies = { git = "https://github.com/Jeffail/tokesies" }
+  config = "0.9"

--- a/ripsaw-config.toml
+++ b/ripsaw-config.toml
@@ -1,0 +1,2 @@
+debug = false
+cut_width_inches = 0.125

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,28 @@
+extern crate config;
 extern crate ripsaw;
 
 use std::io;
+use std::collections::HashMap;
 
 use ripsaw::Lumber;
 use ripsaw::CutList;
+use ripsaw::Settings;
 
 fn main() {
+    let mut settings = config::Config::default();
+    let mut settings_hashmap: HashMap<String, String> = HashMap::new();
+    settings
+        .merge(config::File::with_name("ripsaw-config"))
+        .unwrap()
+        .merge(config::Environment::with_prefix("RIPSAW"))
+        .unwrap();
+
+    // Deserialize to a hash map.
+    settings_hashmap = settings.try_into::<HashMap<String, String>>().unwrap();
+    let settings = Settings::new_from_hashmap(settings_hashmap);
+
     let mut input;
-    let mut cut_list = CutList::new(None);
+    let mut cut_list = CutList::new_with_settings(settings);
 
     loop {
         input = String::new();


### PR DESCRIPTION
We can add different lumber types, different lengths of lumber, and other
configurable items in the future. Right now, it only contains the width of
the blade/cut.

Refs #2.